### PR TITLE
devops: Pass errors back to the Heroku build framework

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -o errexit
+set -o pipefail
+
 ROOT_BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3


### PR DESCRIPTION
Pass errors from other scripts back up to the Heroku build framework so that errors in building the app prevent the result from being deployed.

- Heroku already does this in their scripts, see the top of `bin/og_compile` for an example.
- `errexit` makes the script exit immediately if any command in the script exits with a non-zero exit code, with the same exit code.
- `pipefail` makes it so that any command in a pipe (`command1 | command2`) that returns a non-zero exit code will cause the entire script to fail; otherwise, only the exit code of the last command in the chain matters (i.e. the exit code of `command1` would be ignored, and only the exit code of `command2` would matter).

See https://github.com/Compt/heroku-buildpack-nodejs/pull/4 for how I tested.

[COMPT-7080]


[COMPT-7080]: https://comptinc.atlassian.net/browse/COMPT-7080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ